### PR TITLE
Allocate memory in one go

### DIFF
--- a/s2/cellid.go
+++ b/s2/cellid.go
@@ -276,7 +276,7 @@ func (ci CellID) AllNeighbors(level int) []CellID {
 		return nil
 	}
 
-	var neighbors []CellID
+	var neighbors = make([]CellID, 0, 8)
 
 	face, i, j, _ := ci.faceIJOrientation()
 


### PR DESCRIPTION
The method AllNeighbors returns a maximum of 8 CellIDs, pre-allocates memory to avoid triggering expansion, and enhances performance.